### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
     </engines>
 
     <!-- dependencies -->
-    <dependency id="cordova-plugin-device" />
+    <dependency id="org.apache.cordova.device" />
 
     <!-- info -->
     <info>
@@ -79,7 +79,7 @@
     <!-- android -->
     <platform name="android">
 
-        <dependency id="cordova-plugin-android-support-v4" />
+        <dependency id="android.support.v4" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="LocalNotification">


### PR DESCRIPTION
Dependencies are still being referenced by their old ID in Intel XDK Cordova 4.1.2. Need to revert, else build fails.
